### PR TITLE
Feat: Improve configure command logic

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -55,13 +55,13 @@ tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
 name = "beta9"
-version = "0.1.98"
+version = "0.1.100"
 description = ""
 optional = false
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "beta9-0.1.98-py3-none-any.whl", hash = "sha256:bf0d8ac3a1b2497d76c364021ef6ef23176037e44a2be0edc58bcd99979bf64f"},
-    {file = "beta9-0.1.98.tar.gz", hash = "sha256:1a52171ee878f9c2996fcb15764576e06f4916c5fa1ac26699bf74a2a7480f2e"},
+    {file = "beta9-0.1.100-py3-none-any.whl", hash = "sha256:1706056729175cf267b3f1151ee53a62b91bd4e827b543f40807e6dbc30f3c60"},
+    {file = "beta9-0.1.100.tar.gz", hash = "sha256:178006c58911ece004f12e1ce6eee2ccdeb7904d681b3d499ba7d7e4347f67e1"},
 ]
 
 [package.dependencies]
@@ -1317,4 +1317,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "68a6754840e4d05261fca6a6f70419c0bdadd679e4302507790c863b12687919"
+content-hash = "3f59f2a649ea37d1eedf42518298df1c4ddf8606d672ff5dde513ce9c670bd7d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beam-client"
-version = "0.2.97"
+version = "0.2.98"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [
@@ -10,7 +10,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-beta9 = "^0.1.98"
+beta9 = "^0.1.100"
 requests = "^2.31.0"
 websockets = "^12.0"
 

--- a/src/beam/cli/configure.py
+++ b/src/beam/cli/configure.py
@@ -54,22 +54,22 @@ def configure(token: str, name: str):
         while True:
             if terminal.prompt(
                 text=f"Context '{name}' already exists. Overwrite? (y/n)", default="n"
-            ).lower() not in ["y", "yes"]:
-                if terminal.prompt(
-                    text="Would you like to provide a different context name? (y/n)", default="n"
-                ).lower() in ["y", "yes"]:
-                    new_name = terminal.prompt(text="Enter a new context name")
-                    if new_name == name:
-                        msg = "New context name cannot be the same as the existing name"
-                        terminal.error(msg, exit=False)
-                    else:
-                        name = new_name
-                        break
-                else:
-                    terminal.warn(f"No changes made to {config_path}")
-                    return
-            else:
+            ).lower() not in ["n", "no"]:
                 break
+
+            if terminal.prompt(
+                text="Would you like to provide a different context name? (y/n)", default="n"
+            ).lower() not in ["y", "yes"]:
+                terminal.warn(f"No changes made to {config_path}")
+                return
+
+            new_name = terminal.prompt(text="Enter a new context name")
+            if new_name in contexts:
+                terminal.error(f"Context '{new_name}' already exists.", exit=False)
+                continue
+
+            name = new_name
+            break
 
     context = ConfigContext(
         token=token, gateway_host=settings.gateway_host, gateway_port=settings.gateway_port

--- a/src/beam/cli/configure.py
+++ b/src/beam/cli/configure.py
@@ -1,7 +1,7 @@
 import click
 from beta9 import terminal
 from beta9.cli.extraclick import ClickCommonGroup
-from beta9.config import ConfigContext, get_settings, load_config, save_config
+from beta9.config import DEFAULT_CONTEXT_NAME, ConfigContext, get_settings, load_config, save_config
 
 
 def validate_token(ctx: click.Context, param: click.Parameter, value: str):
@@ -41,7 +41,9 @@ def common(**_):
 @click.argument(
     "name",
     nargs=1,
-    required=True,
+    type=click.STRING,
+    required=False,
+    default=DEFAULT_CONTEXT_NAME,
 )
 def configure(token: str, name: str):
     settings = get_settings()
@@ -49,9 +51,25 @@ def configure(token: str, name: str):
     contexts = load_config(config_path)
 
     if name in contexts and contexts[name].is_valid():
-        text = f"Context '{name}' already exists. Overwrite?"
-        if terminal.prompt(text=text, default="n").lower() in ["n", "no"]:
-            return
+        while True:
+            if terminal.prompt(
+                text=f"Context '{name}' already exists. Overwrite? (y/n)", default="n"
+            ).lower() not in ["y", "yes"]:
+                if terminal.prompt(
+                    text="Would you like to provide a different context name? (y/n)", default="n"
+                ).lower() in ["y", "yes"]:
+                    new_name = terminal.prompt(text="Enter a new context name")
+                    if new_name == name:
+                        msg = "New context name cannot be the same as the existing name"
+                        terminal.error(msg, exit=False)
+                    else:
+                        name = new_name
+                        break
+                else:
+                    terminal.warn(f"No changes made to {config_path}")
+                    return
+            else:
+                break
 
     context = ConfigContext(
         token=token, gateway_host=settings.gateway_host, gateway_port=settings.gateway_port
@@ -59,7 +77,6 @@ def configure(token: str, name: str):
 
     # Save context to config
     contexts[name] = context
-
     save_config(contexts=contexts, path=config_path)
 
-    terminal.success("Configured beam context 🎉!")
+    terminal.success(f"Added new context to {config_path}")

--- a/src/beam/cli/configure.py
+++ b/src/beam/cli/configure.py
@@ -65,7 +65,7 @@ def configure(token: str, name: str):
 
             new_name = terminal.prompt(text="Enter a new context name")
             if new_name in contexts:
-                terminal.error(f"Context '{new_name}' already exists.", exit=False)
+                terminal.warn("The context you entered already exists.")
                 continue
 
             name = new_name


### PR DESCRIPTION
- Update beta9 package
- Don't require a name for the context and default to "default"
- If you don't want to overwrite the context, prompt for a different context name
- If you exit from the overwrite/different name prompts, print out that no changes were made
- When there's a successful change to the config, change the message to include the path of the config.

Resolve BE-1998 BE-1996