### PR TITLE
fix[example.py]: fix typo

### DIFF
--- a/src/beam/cli/example.py
+++ b/src/beam/cli/example.py
@@ -34,7 +34,7 @@ def management(**_):
 
 @common.command(
     name="create-app",
-    help="Downloads an examlpe app.",
+    help="Downloads an example app.",
 )
 @click.argument(
     "name",


### PR DESCRIPTION
Quick typo fix for a help message.