### PR TITLE
Improve Beam CLI upgrade guidance

### DIFF
--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -851,7 +851,7 @@ version = "24.1"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
     {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
@@ -1692,4 +1692,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.8"
-content-hash = "c5fa52e3d98190a7d022c5ca7dabe9d0e80da6437b2c36191bf638cecb75796e"
+content-hash = "e8fc2279928ecd8e6cb60b41d1fb76d6794c4071807d322c4ad9c2a6362779bd"

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -123,14 +123,14 @@ typecheck = ["mypy"]
 
 [[package]]
 name = "beta9"
-version = "0.1.262"
+version = "0.1.264"
 description = ""
 optional = false
 python-versions = "<4.0,>=3.8"
 groups = ["main"]
 files = [
-    {file = "beta9-0.1.262-py3-none-any.whl", hash = "sha256:bd71e795c42175e727992ecfd5c45b4a96006233927a187fa395a62178ecebc2"},
-    {file = "beta9-0.1.262.tar.gz", hash = "sha256:2bb1b1a5b9d89d07e4ecffcfe0332019c8dce5280f134befeb6a29c271f59f0b"},
+    {file = "beta9-0.1.264-py3-none-any.whl", hash = "sha256:1f06ee7084a1d136468e1716412c384b27e19c66c875ffe2a7ff361693c3b116"},
+    {file = "beta9-0.1.264.tar.gz", hash = "sha256:9bb555874a5f21eaa62a9e808bcfbc158a0348507dcca2ecf143c511ed8e3329"},
 ]
 
 [package.dependencies]
@@ -1692,4 +1692,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.8"
-content-hash = "e8fc2279928ecd8e6cb60b41d1fb76d6794c4071807d322c4ad9c2a6362779bd"
+content-hash = "2809debd7a70b0e8859fe483187b848c59d05f81f253e1e2cc9cda8d6e44c884"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "beam-client"
-version = "0.2.204"
+version = "0.2.206"
 description = ""
 authors = ["beam.cloud <support@beam.cloud>"]
 packages = [
@@ -13,7 +13,7 @@ python = "^3.8"
 packaging = ">=24.0"
 requests = "^2.31.0"
 websockets = ">=13,<16"
-beta9 = "^0.1.262"
+beta9 = "^0.1.264"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.1"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,6 +10,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
+packaging = ">=24.0"
 requests = "^2.31.0"
 websockets = ">=13,<16"
 beta9 = "^0.1.262"

--- a/python/src/beam/cli/utils.py
+++ b/python/src/beam/cli/utils.py
@@ -26,13 +26,20 @@ def check_version():
     if current_version >= minimum_version:
         return
 
+    # Use the interpreter that is running the Beam CLI. A bare `pip` executable
+    # may belong to a different Python installation, leaving this CLI unchanged.
+    upgrade_command = f'"{sys.executable}" -m pip install --upgrade beam-client'
+
     click.echo(
         (
-            f"{click.style('Update Required', fg='yellow', bold=True)}\n\n"
-            f"Your current version: {click.style(str(current_version), bold=True)}\n"
-            f"Minimum required version: {click.style(str(minimum_version), fg='yellow', bold=True)}\n"
-            "\nPlease upgrade to the latest version.\n"
-            f"  {click.style('pip install --upgrade beam-client', bold=True)}\n"
+            f"{click.style('Beam CLI update required', fg='yellow', bold=True)}\n\n"
+            f"Installed: {click.style(str(current_version), bold=True)}\n"
+            f"Minimum:   {click.style(str(minimum_version), fg='yellow', bold=True)}\n"
+            f"Python:    {sys.executable}\n"
+            "\nUpgrade this installation (not a different `pip` on your PATH):\n"
+            f"  {click.style(upgrade_command, bold=True)}\n"
+            "\nThen verify:\n"
+            f"  {click.style('beam --version', bold=True)}\n"
         )
     )
 

--- a/python/tests/cli/test_utils.py
+++ b/python/tests/cli/test_utils.py
@@ -1,0 +1,31 @@
+import sys
+
+import pytest
+
+from beam.cli import utils
+
+
+class FakeResponse:
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return {"version": "0.2.202"}
+
+
+def test_check_version_upgrades_the_python_environment_running_beam(monkeypatch, capsys):
+    monkeypatch.setattr(utils.requests, "get", lambda *args, **kwargs: FakeResponse())
+    monkeypatch.setattr(utils.metadata, "version", lambda package: "0.2.191")
+    monkeypatch.setattr(sys, "executable", "/opt/Beam Client/bin/python")
+
+    with pytest.raises(SystemExit) as exc_info:
+        utils.check_version()
+
+    assert exc_info.value.code == 1
+    output = capsys.readouterr().out
+    assert "Beam CLI update required" in output
+    assert "Installed: 0.2.191" in output
+    assert "Minimum:   0.2.202" in output
+    assert "Python:    /opt/Beam Client/bin/python" in output
+    assert '"/opt/Beam Client/bin/python" -m pip install --upgrade beam-client' in output
+    assert "beam --version" in output


### PR DESCRIPTION
## What changed

- show the resolved Python interpreter behind the running `beam` command
- recommend upgrading with that interpreter instead of a potentially unrelated bare `pip`
- add a post-upgrade `beam --version` verification step
- declare `packaging` as a direct runtime dependency
- add regression coverage for the upgrade notice

## Why

A user can run `beam` through a pyenv shim while a bare `pip` points at another Python environment. In that case, `pip install --upgrade beam-client` may report a new package version without updating the Beam CLI that is actually running. A clean wheel installation also exposed that the version-check module imported `packaging` without declaring it directly, which could crash the CLI before the guidance appeared.

## Impact

The update-required message is now actionable for pyenv, virtualenv, and other multi-Python setups: it identifies the real environment, provides a copyable command that upgrades that exact installation, and tells the user how to verify the result.

## Validation

- `.venv/bin/pytest -q`
- `.venv/bin/ruff check src tests`
- `.venv/bin/python -m build --wheel`
- isolated clean-wheel test through a shimmed `beam` executable against a mock minimum-version endpoint